### PR TITLE
Add linker argument for IOKit framework on macOS universal builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,9 @@ model {
         }
       }
       binaries.all {
+        if (it.targetPlatform.name == 'osxuniversal') {
+          linker.args '-framework', 'IOKit'
+        }
         if (it.targetPlatform.name == nativeUtils.wpi.platforms.roborio) {
           it.buildable = false
         }


### PR DESCRIPTION
Fixes broken CANBridge builds on any macOS platform.