### PR TITLE
Update artifact uploading workflows, add ARM workflows, update release workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,12 +33,12 @@ jobs:
     container: ${{ matrix.container }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.sha }}
 
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: 11
@@ -128,18 +128,18 @@ jobs:
     container: ${{ matrix.container }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.sha }}
 
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: 11
 
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             .gradle
@@ -218,7 +218,7 @@ jobs:
 
       # Upload build artifact
       - name: Upload build artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: CANBridge-${{ github.sha }}-${{ matrix.platform-type }}-${{ matrix.name }}
           path: CANBridge-artifacts/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,7 @@ jobs:
             build-options: "-Ponlylinuxarm32"
             platform-type: linuxarm32
     runs-on: ubuntu-latest
+    name: "Build - ${{ matrix.name }}"
     container: ${{ matrix.container }}
     steps:
       - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,20 +21,25 @@ jobs:
         include:
           - os: windows-latest
             container: ''
-            name: windows64
+            name: Win64
+            platform-type: windowsx86-64
           - os: ubuntu-latest
             container: ''
-            name: linux64
-#          - os: ubuntu-latest-arm64
-#            container: ''
-#            name: linuxarm64
+            name: Linux64
+            platform-type: linuxx86-64
+          # - os: ubuntu-latest-arm64
+          #   container: ''
+          #   name: linuxarm64
+          #   platform-type: linuxarm64
           - os: macos-latest
             container: ''
-            name: macosarm64
+            name: MacOSARM64
+            platform-type: osxuniversal
           - os: macos-13
             container: ''
-            name: macosintel64
-    name: "build-${{ matrix.name }}"
+            name: MacOS64
+            platform-type: osxuniversal
+    name: "Build - ${{ matrix.name }}"
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
     steps:
@@ -65,45 +70,26 @@ jobs:
           ./gradlew outputVersions publish ${{ matrix.build-options }} -PreleaseMode
 
       - name: Download WPILib HAL artifacts and headers, gather all needed headers
-        # if: contains(matrix.name, 'windows64')
         run : |
           halVersion=$(cat wpiHalVersion.txt)
           
           # Download WPILib artifacts from Artifactory 
-          halWindowsUrl=https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/hal/hal-cpp/"$halVersion"/hal-cpp-"$halVersion"-windowsx86-64.zip
-          halMacUrl=https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/hal/hal-cpp/"$halVersion"/hal-cpp-"$halVersion"-osxuniversal.zip
-          halLinux64Url=https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/hal/hal-cpp/"$halVersion"/hal-cpp-"$halVersion"-linuxx86-64.zip
-          halLinuxArmUrl=https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/hal/hal-cpp/"$halVersion"/hal-cpp-"$halVersion"-linuxarm64.zip
+          halPlatformUrl=https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/hal/hal-cpp/"$halVersion"/hal-cpp-"$halVersion"-${{ matrix.platform-type }}.zip
           halHeadersUrl=https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/hal/hal-cpp/"$halVersion"/hal-cpp-"$halVersion"-headers.zip
 
-          utilWindowsUrl=https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/wpiutil/wpiutil-cpp/"$halVersion"/wpiutil-cpp-"$halVersion"-windowsx86-64.zip
-          utilMacUrl=https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/wpiutil/wpiutil-cpp/"$halVersion"/wpiutil-cpp-"$halVersion"-osxuniversal.zip
-          utilLinux64Url=https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/wpiutil/wpiutil-cpp/"$halVersion"/wpiutil-cpp-"$halVersion"-linuxx86-64.zip
-          utilLinuxArmUrl=https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/wpiutil/wpiutil-cpp/"$halVersion"/wpiutil-cpp-"$halVersion"-linuxarm64.zip
+          utilPlatformUrl=https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/wpiutil/wpiutil-cpp/"$halVersion"/wpiutil-cpp-"$halVersion"-${{ matrix.platform-type }}.zip
           utilHeadersUrl=https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/wpiutil/wpiutil-cpp/"$halVersion"/wpiutil-cpp-"$halVersion"-headers.zip
 
-          curl -o halWindows.zip "$halWindowsUrl"
-          curl -o halMac.zip "$halMacUrl"
-          curl -o halLinux64.zip "$halLinux64Url"
-          curl -o halLinuxArm.zip "$halLinuxArmUrl"
+          curl -o halPlatform.zip "$halPlatformUrl"
           curl -o halHeaders.zip "$halHeadersUrl"
 
-          curl -o utilWindows.zip "$utilWindowsUrl"
-          curl -o utilMac.zip "$utilMacUrl"
-          curl -o utilLinux64.zip "$utilLinux64Url"
-          curl -o utilLinuxArm.zip "$utilLinuxArmUrl"
+          curl -o utilPlatform.zip "$utilPlatformUrl"
           curl -o utilHeaders.zip "$utilHeadersUrl"
 
-          unzip halWindows.zip -d halWindows
-          unzip halMac.zip -d halMac
-          unzip halLinux64.zip -d halLinux64
-          unzip halLinuxArm.zip -d halLinuxArm
+          unzip halPlatform.zip -d halPlatform
           unzip halHeaders.zip -d halHeaders
 
-          unzip utilWindows.zip -d utilWindows
-          unzip utilMac.zip -d utilMac
-          unzip utilLinux64.zip -d utilLinux64
-          unzip utilLinuxArm.zip -d utilLinuxArm
+          unzip utilPlatform.zip -d utilPlatform
           unzip utilHeaders.zip -d utilHeaders
 
           # Gather all of the the needed headers
@@ -116,65 +102,48 @@ jobs:
           mkdir -p CANBridge-artifacts
           7z a CANBridge-artifacts/headers.zip ./headers-for-artifact/*
 
-      # Put release files together in one directory
+      # Put Windows release files together in one directory
       - name: Create Artifact (windows64)
-        if: contains(matrix.name, 'windows64')
+        if: matrix.platform-type == 'windowsx86-64'
         run: |
-          mkdir -p CANBridge-artifacts
           cp build/libs/cANBridge/static/windowsx86-64/release/CANBridge.lib CANBridge-artifacts/CANBridge-static.lib
           cp build/libs/cANBridge/shared/windowsx86-64/release/CANBridge.dll CANBridge-artifacts/CANBridge.dll
           cp build/libs/cANBridge/shared/windowsx86-64/release/CANBridge.lib CANBridge-artifacts/CANBridge.lib
 
-          cp halWindows/windows/x86-64/shared/wpiHal.dll CANBridge-artifacts/wpiHal.dll
-          cp halWindows/windows/x86-64/shared/wpiHal.lib CANBridge-artifacts/wpiHal.lib
-          cp halMac/osx/universal/shared/libwpiHal.dylib CANBridge-artifacts/libwpiHal.dylib
-          cp halLinux64/linux/x86-64/shared/libwpiHal.so CANBridge-artifacts/libwpiHal.so
-          cp halLinuxArm/linux/arm64/shared/libwpiHal.so CANBridge-artifacts/libwpiHal-arm64.so
+          cp halPlatform/windows/x86-64/shared/wpiHal.dll CANBridge-artifacts/wpiHal.dll
+          cp halPlatform/windows/x86-64/shared/wpiHal.lib CANBridge-artifacts/wpiHal.lib
 
-          cp utilWindows/windows/x86-64/shared/wpiutil.dll CANBridge-artifacts/wpiutil.dll
-          cp utilWindows/windows/x86-64/shared/wpiutil.lib CANBridge-artifacts/wpiutil.lib
-          cp utilMac/osx/universal/shared/libwpiutil.dylib CANBridge-artifacts/libwpiutil.dylib
-          cp utilLinux64/linux/x86-64/shared/libwpiutil.so CANBridge-artifacts/libwpiutil.so
-          cp utilLinuxArm/linux/arm64/shared/libwpiutil.so CANBridge-artifacts/libwpiutil-arm64.so
+          cp utilPlatform/windows/x86-64/shared/wpiutil.dll CANBridge-artifacts/wpiutil.dll
+          cp utilPlatform/windows/x86-64/shared/wpiutil.lib CANBridge-artifacts/wpiutil.lib
 
-      # Put release files together in one directory
+      # Put Linux release files together in one directory
       - name: Create Artifact (linux64)
-        if: contains(matrix.name, 'linux64')
+        if: matrix.platform-type == 'linuxx86-64'
         run: |
-          mkdir -p CANBridge-artifacts
           # TODO: Include built binaries for macos/arm64, macos/x86-64, linux/x86-64, linux/arm64
 
-      # Put release files together in one directory
+      # Put Linux ARM release files together in one directory
       - name: Create Artifact (linuxarm64)
-        if: contains(matrix.name, 'linuxarm64')
+        if: matrix.platform-type == 'linuxarm64'
         run: |
-          mkdir -p CANBridge-artifacts
           # TODO: Include built binaries for macos/arm64, macos/x86-64, linux/x86-64, linux/arm64
 
-      # Put release files together in one directory
-      - name: Create Artifact (macosarm64)
-        if: contains(matrix.name, 'macosarm64')
+      # Put macOS release files together in one directory
+      - name: Create Artifact (osxuniversal)
+        if: matrix.platform-type == 'osxuniversal'
         run: |
-          mkdir -p CANBridge-artifacts
           cp build/libs/cANBridge/static/osxuniversal/release/libCANBridge.a CANBridge-artifacts/libCANBridge.a
           cp build/libs/cANBridge/shared/osxuniversal/release/libCANBridge.dylib CANBridge-artifacts/libCANBridge.dylib
 
-          cp halMac/osx/universal/shared/libwpiHal.dylib CANBridge-artifacts/libwpiHal.dylib
+          cp halPlatform/osx/universal/shared/libwpiHal.dylib CANBridge-artifacts/libwpiHal.dylib
 
-          cp utilMac/osx/universal/shared/libwpiutil.dylib CANBridge-artifacts/libwpiutil.dylib
-
-      # Put release files together in one directory
-      - name: Create Artifact (macosintel64)
-        if: contains(matrix.name, 'macosintel64')
-        run: |
-          mkdir -p CANBridge-artifacts
-          # TODO: Include built binaries for macos/arm64, macos/x86-64, linux/x86-64, linux/arm64
+          cp utilPlatform/osx/universal/shared/libwpiutil.dylib CANBridge-artifacts/libwpiutil.dylib
 
       # Upload build artifact
       - name: Upload build artifact
         uses: actions/upload-artifact@v3
         with:
-          name: CANBridge-${{ github.sha }}
+          name: CANBridge-${{ github.sha }}-${{ matrix.platform-type }}-${{ matrix.name }}
           path: CANBridge-artifacts/
 
       # Upload version.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ defaults:
 jobs:
   build-docker:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - container: wpilib/aarch64-cross-ubuntu:bullseye-22.04
@@ -72,6 +73,8 @@ jobs:
 
           # Zip the needed headers and put them in the appropriate location for artifact upload
           mkdir -p CANBridge-artifacts
+          # Install 7zip
+          sudo apt install -y p7zip-full
           7z a CANBridge-artifacts/headers.zip ./headers-for-artifact/*
 
       # Put Linux ARM release files together in one directory

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
           java-version: 11
       - name: Build
         run: |
-          ./gradlew outputVersions publish ${{ matrix.build-options }} -PreleaseMode --info
+          ./gradlew outputVersions publish ${{ matrix.build-options }} -PreleaseMode
       - name: Install 7zip
         run: |
           sudo apt-get update
@@ -80,26 +80,14 @@ jobs:
           7z a CANBridge-artifacts/headers.zip ./headers-for-artifact/*
 
       # Put Linux ARM release files together in one directory
-      - name: Create Artifact (linuxarm64)
-        if: matrix.platform-type == 'linuxarm64'
+      - name: Create Artifact
         run: |
-          cp build/libs/cANBridge/static/linuxarm64/release/libCANBridge.a CANBridge-artifacts/libCANBridge.a
-          cp build/libs/cANBridge/shared/linuxarm64/release/libCANBridge.so CANBridge-artifacts/libCANBridge.so
+          cp build/libs/cANBridge/static/release/libCANBridge.a CANBridge-artifacts/libCANBridge.a
+          cp build/libs/cANBridge/shared/release/libCANBridge.so CANBridge-artifacts/libCANBridge.so
 
           cp halPlatform/linux/arm64/shared/libwpiHal.so CANBridge-artifacts/libwpiHal.so
 
           cp utilPlatform/linux/arm64/shared/libwpiutil.so CANBridge-artifacts/libwpiutil.so
-
-      # Put Linux ARM release files together in one directory
-      - name: Create Artifact (linuxarm32)
-        if: matrix.platform-type == 'linuxarm32'
-        run: |
-          cp build/libs/cANBridge/static/linuxarm32/release/libCANBridge.a CANBridge-artifacts/libCANBridge.a
-          cp build/libs/cANBridge/shared/linuxarm32/release/libCANBridge.so CANBridge-artifacts/libCANBridge.so
-
-          cp halPlatform/linux/arm32/shared/libwpiHal.so CANBridge-artifacts/libwpiHal.so
-
-          cp utilPlatform/linux/arm32/shared/libwpiutil.so CANBridge-artifacts/libwpiutil.so
 
       # Upload build artifact
       - name: Upload build artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,95 @@ defaults:
     shell: bash
 
 jobs:
-  build:
+  build-docker:
+    strategy:
+      matrix:
+        include:
+          - container: wpilib/aarch64-cross-ubuntu:bullseye-22.04
+            name: LinuxARM64
+            build-options: "-Ponlylinuxarm64"
+            platform-type: linuxarm64
+          - container: wpilib/raspbian-cross-ubuntu:bullseye-22.04
+            name: LinuxARM32
+            build-options: "-Ponlylinuxarm32"
+            platform-type: linuxarm32
+    runs-on: ubuntu-latest
+    container: ${{ matrix.container }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.sha }}
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: 11
+      - name: Build
+        run: |
+          ./gradlew outputVersions publish ${{ matrix.build-options }} -PreleaseMode
+      - name: Download WPILib HAL artifacts and headers, gather all needed headers
+        run : |
+          halVersion=$(cat wpiHalVersion.txt)
+          
+          # Download WPILib artifacts from Artifactory 
+          halPlatformUrl=https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/hal/hal-cpp/"$halVersion"/hal-cpp-"$halVersion"-${{ matrix.platform-type }}.zip
+          halHeadersUrl=https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/hal/hal-cpp/"$halVersion"/hal-cpp-"$halVersion"-headers.zip
+
+          utilPlatformUrl=https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/wpiutil/wpiutil-cpp/"$halVersion"/wpiutil-cpp-"$halVersion"-${{ matrix.platform-type }}.zip
+          utilHeadersUrl=https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/wpiutil/wpiutil-cpp/"$halVersion"/wpiutil-cpp-"$halVersion"-headers.zip
+
+          curl -o halPlatform.zip "$halPlatformUrl"
+          curl -o halHeaders.zip "$halHeadersUrl"
+
+          curl -o utilPlatform.zip "$utilPlatformUrl"
+          curl -o utilHeaders.zip "$utilHeadersUrl"
+
+          unzip halPlatform.zip -d halPlatform
+          unzip halHeaders.zip -d halHeaders
+
+          unzip utilPlatform.zip -d utilPlatform
+          unzip utilHeaders.zip -d utilHeaders
+
+          # Gather all of the the needed headers
+          mkdir headers-for-artifact
+          cp -r halHeaders/hal headers-for-artifact
+          cp -r utilHeaders/wpi headers-for-artifact
+          cp -r src/main/native/include/* headers-for-artifact
+
+          # Zip the needed headers and put them in the appropriate location for artifact upload
+          mkdir -p CANBridge-artifacts
+          7z a CANBridge-artifacts/headers.zip ./headers-for-artifact/*
+
+      # Put Linux ARM release files together in one directory
+      - name: Create Artifact (linuxarm64)
+        if: matrix.platform-type == 'linuxarm64'
+        run: |
+          cp build/libs/cANBridge/static/linuxarm64/release/libCANBridge.a CANBridge-artifacts/libCANBridge.a
+          cp build/libs/cANBridge/shared/linuxarm64/release/libCANBridge.so CANBridge-artifacts/libCANBridge.so
+
+          cp halPlatform/linux/arm64/shared/libwpiHal.so CANBridge-artifacts/libwpiHal.so
+
+          cp utilPlatform/linux/arm64/shared/libwpiutil.so CANBridge-artifacts/libwpiutil.so
+
+      # Put Linux ARM release files together in one directory
+      - name: Create Artifact (linuxarm32)
+        if: matrix.platform-type == 'linuxarm32'
+        run: |
+          cp build/libs/cANBridge/static/linuxarm32/release/libCANBridge.a CANBridge-artifacts/libCANBridge.a
+          cp build/libs/cANBridge/shared/linuxarm32/release/libCANBridge.so CANBridge-artifacts/libCANBridge.so
+
+          cp halPlatform/linux/arm32/shared/libwpiHal.so CANBridge-artifacts/libwpiHal.so
+
+          cp utilPlatform/linux/arm32/shared/libwpiutil.so CANBridge-artifacts/libwpiutil.so
+
+      # Upload build artifact
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: CANBridge-${{ github.sha }}-${{ matrix.platform-type }}-${{ matrix.name }}
+          path: CANBridge-artifacts/
+  build-native:
     timeout-minutes: 15
     strategy:
       fail-fast: false
@@ -27,10 +115,6 @@ jobs:
             container: ''
             name: Linux64
             platform-type: linuxx86-64
-          # - os: ubuntu-latest-arm64
-          #   container: ''
-          #   name: linuxarm64
-          #   platform-type: linuxarm64
           - os: macos-latest
             container: ''
             name: MacOSARM64
@@ -120,13 +204,12 @@ jobs:
       - name: Create Artifact (linux64)
         if: matrix.platform-type == 'linuxx86-64'
         run: |
-          # TODO: Include built binaries for macos/arm64, macos/x86-64, linux/x86-64, linux/arm64
+          cp build/libs/cANBridge/static/linuxx86-64/release/libCANBridge.a CANBridge-artifacts/libCANBridge.a
+          cp build/libs/cANBridge/shared/linuxx86-64/release/libCANBridge.so CANBridge-artifacts/libCANBridge.so
 
-      # Put Linux ARM release files together in one directory
-      - name: Create Artifact (linuxarm64)
-        if: matrix.platform-type == 'linuxarm64'
-        run: |
-          # TODO: Include built binaries for macos/arm64, macos/x86-64, linux/x86-64, linux/arm64
+          cp halPlatform/linux/x86-64/shared/libwpiHal.so CANBridge-artifacts/libwpiHal.so
+
+          cp utilPlatform/linux/x86-64/shared/libwpiutil.so CANBridge-artifacts/libwpiutil.so
 
       # Put macOS release files together in one directory
       - name: Create Artifact (osxuniversal)
@@ -145,10 +228,3 @@ jobs:
         with:
           name: CANBridge-${{ github.sha }}-${{ matrix.platform-type }}-${{ matrix.name }}
           path: CANBridge-artifacts/
-
-      # Upload version.txt
-      - name: Upload version artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: version
-          path: build/allOutputs/version.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,11 +36,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.sha }}
+
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: 11
+
       - name: Build
         run: |
           ./gradlew outputVersions publish ${{ matrix.build-options }} -PreleaseMode
@@ -48,36 +50,37 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y p7zip-full
-      - name: Download WPILib HAL artifacts and headers, gather all needed headers
+
+      - name: Download WPILib HAL artifacts and headers for ${{ matrix.platform-type }}
         run : |
           halVersion=$(cat wpiHalVersion.txt)
           
-          # Download WPILib artifacts from Artifactory 
           halPlatformUrl=https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/hal/hal-cpp/"$halVersion"/hal-cpp-"$halVersion"-${{ matrix.platform-type }}.zip
           halHeadersUrl=https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/hal/hal-cpp/"$halVersion"/hal-cpp-"$halVersion"-headers.zip
-
           utilPlatformUrl=https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/wpiutil/wpiutil-cpp/"$halVersion"/wpiutil-cpp-"$halVersion"-${{ matrix.platform-type }}.zip
           utilHeadersUrl=https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/wpiutil/wpiutil-cpp/"$halVersion"/wpiutil-cpp-"$halVersion"-headers.zip
 
           curl -o halPlatform.zip "$halPlatformUrl"
           curl -o halHeaders.zip "$halHeadersUrl"
-
           curl -o utilPlatform.zip "$utilPlatformUrl"
           curl -o utilHeaders.zip "$utilHeadersUrl"
 
+      - name: Unzip WPILib HAL artifacts and headers
+        run: |
           unzip halPlatform.zip -d halPlatform
           unzip halHeaders.zip -d halHeaders
-
           unzip utilPlatform.zip -d utilPlatform
           unzip utilHeaders.zip -d utilHeaders
 
-          # Gather all of the the needed headers
+      - name: Gather all needed headers
+        run: |
           mkdir headers-for-artifact
           cp -r halHeaders/hal headers-for-artifact
           cp -r utilHeaders/wpi headers-for-artifact
           cp -r src/main/native/include/* headers-for-artifact
 
-          # Zip the needed headers and put them in the appropriate location for artifact upload
+      - name: Zip the needed headers and put them in the appropriate location for artifact upload
+        run: |
           mkdir -p CANBridge-artifacts
           7z a CANBridge-artifacts/headers.zip ./headers-for-artifact/*
 
@@ -86,9 +89,7 @@ jobs:
         run: |
           cp build/libs/cANBridge/static/release/libCANBridge.a CANBridge-artifacts/libCANBridge.a
           cp build/libs/cANBridge/shared/release/libCANBridge.so CANBridge-artifacts/libCANBridge.so
-
           cp halPlatform/linux/${{ matrix.arch }}/shared/libwpiHal.so CANBridge-artifacts/libwpiHal.so
-
           cp utilPlatform/linux/${{ matrix.arch }}/shared/libwpiutil.so CANBridge-artifacts/libwpiutil.so
 
       # Upload build artifact
@@ -97,6 +98,7 @@ jobs:
         with:
           name: CANBridge-${{ github.sha }}-${{ matrix.platform-type }}-${{ matrix.name }}
           path: CANBridge-artifacts/
+
   build-native:
     timeout-minutes: 15
     strategy:
@@ -111,6 +113,8 @@ jobs:
             container: ''
             name: Linux64
             platform-type: linuxx86-64
+          # GitHub hosted runner `macos-latest` is arm64, which is why we need to specify `macos-13` for x86_64
+          # See https://github.com/actions/runner-images?tab=readme-ov-file#available-images for more information
           - os: macos-latest
             container: ''
             name: MacOSARM64
@@ -149,36 +153,36 @@ jobs:
         run: |
           ./gradlew outputVersions publish ${{ matrix.build-options }} -PreleaseMode
 
-      - name: Download WPILib HAL artifacts and headers, gather all needed headers
+      - name: Download WPILib HAL artifacts and headers for ${{ matrix.platform-type }}
         run : |
           halVersion=$(cat wpiHalVersion.txt)
           
-          # Download WPILib artifacts from Artifactory 
           halPlatformUrl=https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/hal/hal-cpp/"$halVersion"/hal-cpp-"$halVersion"-${{ matrix.platform-type }}.zip
           halHeadersUrl=https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/hal/hal-cpp/"$halVersion"/hal-cpp-"$halVersion"-headers.zip
-
           utilPlatformUrl=https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/wpiutil/wpiutil-cpp/"$halVersion"/wpiutil-cpp-"$halVersion"-${{ matrix.platform-type }}.zip
           utilHeadersUrl=https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/wpiutil/wpiutil-cpp/"$halVersion"/wpiutil-cpp-"$halVersion"-headers.zip
 
           curl -o halPlatform.zip "$halPlatformUrl"
           curl -o halHeaders.zip "$halHeadersUrl"
-
           curl -o utilPlatform.zip "$utilPlatformUrl"
           curl -o utilHeaders.zip "$utilHeadersUrl"
 
+      - name: Unzip WPILib HAL artifacts and headers
+        run: |
           unzip halPlatform.zip -d halPlatform
           unzip halHeaders.zip -d halHeaders
-
           unzip utilPlatform.zip -d utilPlatform
           unzip utilHeaders.zip -d utilHeaders
 
-          # Gather all of the the needed headers
+      - name: Gather all needed headers
+        run: |
           mkdir headers-for-artifact
           cp -r halHeaders/hal headers-for-artifact
           cp -r utilHeaders/wpi headers-for-artifact
           cp -r src/main/native/include/* headers-for-artifact
 
-          # Zip the needed headers and put them in the appropriate location for artifact upload
+      - name: Zip the needed headers and put them in the appropriate location for artifact upload
+        run: |
           mkdir -p CANBridge-artifacts
           7z a CANBridge-artifacts/headers.zip ./headers-for-artifact/*
 
@@ -189,10 +193,8 @@ jobs:
           cp build/libs/cANBridge/static/windowsx86-64/release/CANBridge.lib CANBridge-artifacts/CANBridge-static.lib
           cp build/libs/cANBridge/shared/windowsx86-64/release/CANBridge.dll CANBridge-artifacts/CANBridge.dll
           cp build/libs/cANBridge/shared/windowsx86-64/release/CANBridge.lib CANBridge-artifacts/CANBridge.lib
-
           cp halPlatform/windows/x86-64/shared/wpiHal.dll CANBridge-artifacts/wpiHal.dll
           cp halPlatform/windows/x86-64/shared/wpiHal.lib CANBridge-artifacts/wpiHal.lib
-
           cp utilPlatform/windows/x86-64/shared/wpiutil.dll CANBridge-artifacts/wpiutil.dll
           cp utilPlatform/windows/x86-64/shared/wpiutil.lib CANBridge-artifacts/wpiutil.lib
 
@@ -202,9 +204,7 @@ jobs:
         run: |
           cp build/libs/cANBridge/static/linuxx86-64/release/libCANBridge.a CANBridge-artifacts/libCANBridge.a
           cp build/libs/cANBridge/shared/linuxx86-64/release/libCANBridge.so CANBridge-artifacts/libCANBridge.so
-
           cp halPlatform/linux/x86-64/shared/libwpiHal.so CANBridge-artifacts/libwpiHal.so
-
           cp utilPlatform/linux/x86-64/shared/libwpiutil.so CANBridge-artifacts/libwpiutil.so
 
       # Put macOS release files together in one directory
@@ -213,9 +213,7 @@ jobs:
         run: |
           cp build/libs/cANBridge/static/osxuniversal/release/libCANBridge.a CANBridge-artifacts/libCANBridge.a
           cp build/libs/cANBridge/shared/osxuniversal/release/libCANBridge.dylib CANBridge-artifacts/libCANBridge.dylib
-
           cp halPlatform/osx/universal/shared/libwpiHal.dylib CANBridge-artifacts/libwpiHal.dylib
-
           cp utilPlatform/osx/universal/shared/libwpiutil.dylib CANBridge-artifacts/libwpiutil.dylib
 
       # Upload build artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,10 @@ jobs:
       - name: Build
         run: |
           ./gradlew outputVersions publish ${{ matrix.build-options }} -PreleaseMode
+      - name: Install 7zip
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y p7zip-full
       - name: Download WPILib HAL artifacts and headers, gather all needed headers
         run : |
           halVersion=$(cat wpiHalVersion.txt)
@@ -73,8 +77,6 @@ jobs:
 
           # Zip the needed headers and put them in the appropriate location for artifact upload
           mkdir -p CANBridge-artifacts
-          # Install 7zip
-          sudo apt install -y p7zip-full
           7z a CANBridge-artifacts/headers.zip ./headers-for-artifact/*
 
       # Put Linux ARM release files together in one directory

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,10 +22,12 @@ jobs:
             name: LinuxARM64
             build-options: "-Ponlylinuxarm64"
             platform-type: linuxarm64
+            arch: arm64
           - container: wpilib/raspbian-cross-ubuntu:bullseye-22.04
             name: LinuxARM32
             build-options: "-Ponlylinuxarm32"
             platform-type: linuxarm32
+            arch: arm32
     runs-on: ubuntu-latest
     name: "Build - ${{ matrix.name }}"
     container: ${{ matrix.container }}
@@ -85,9 +87,9 @@ jobs:
           cp build/libs/cANBridge/static/release/libCANBridge.a CANBridge-artifacts/libCANBridge.a
           cp build/libs/cANBridge/shared/release/libCANBridge.so CANBridge-artifacts/libCANBridge.so
 
-          cp halPlatform/linux/arm64/shared/libwpiHal.so CANBridge-artifacts/libwpiHal.so
+          cp halPlatform/linux/${{ matrix.arch }}/shared/libwpiHal.so CANBridge-artifacts/libwpiHal.so
 
-          cp utilPlatform/linux/arm64/shared/libwpiutil.so CANBridge-artifacts/libwpiutil.so
+          cp utilPlatform/linux/${{ matrix.arch }}/shared/libwpiutil.so CANBridge-artifacts/libwpiutil.so
 
       # Upload build artifact
       - name: Upload build artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
           java-version: 11
       - name: Build
         run: |
-          ./gradlew outputVersions publish ${{ matrix.build-options }} -PreleaseMode
+          ./gradlew outputVersions publish ${{ matrix.build-options }} -PreleaseMode --info
       - name: Install 7zip
         run: |
           sudo apt-get update

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,42 +16,22 @@ jobs:
       TAG_NAME: ${{ env.TAG_NAME }}
       VERSION: ${{ steps.get_version.outputs.version }}
     steps:
-
-      - name: Wait for windows64 build to finish
-        uses: lewagon/wait-on-check-action@v1.3.1 
+      - name: Wait for build workflow to finish
+        uses: actions/github-script@v4
         with:
-          ref: ${{ github.ref }}
-          check-name: 'build-windows64'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 10
-      - name: Wait for linux64 build to finish
-        uses: lewagon/wait-on-check-action@v1.3.1 
-        with:
-          ref: ${{ github.ref }}
-          check-name: 'build-linux64'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 10
-#      - name: Wait for linuxarm64 build to finish
-#        uses: lewagon/wait-on-check-action@v1.3.1 
-#        with:
-#          ref: ${{ github.ref }}
-#          check-name: 'build-linuxarm64'
-#          repo-token: ${{ secrets.GITHUB_TOKEN }}
-#          wait-interval: 10
-      - name: Wait for macosarm64 build to finish
-        uses: lewagon/wait-on-check-action@v1.3.1 
-        with:
-          ref: ${{ github.ref }}
-          check-name: 'build-macosarm64'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 10
-      - name: Wait for macosintel64 build to finish
-        uses: lewagon/wait-on-check-action@v1.3.1 
-        with:
-          ref: ${{ github.ref }}
-          check-name: 'build-macosintel64'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 10
+          script: |
+            const { data: runs } = await github.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'build.yml',
+              branch: 'refs/heads/main',
+              status: 'completed',
+              per_page: 1
+            });
+            if (runs.workflow_runs.length === 0) {
+              core.setFailed('No build workflow runs found');
+            }
+            core.setOutput('run_id', runs.workflow_runs[0].id);
 
       - name: Get tag name
         run: |
@@ -59,7 +39,7 @@ jobs:
 
       # Download artifacts from build workflow
       - name: Download workflow artifacts
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@v6
         with:
           workflow: build.yml
           commit: ${{ github.sha }}
@@ -67,18 +47,10 @@ jobs:
 
       # Get publish.gradle version
       - name: Get publish.gradle version
-        id: get_version
+        id: get-version
         run: |
           echo "version=$(cat version/version.txt)" >> $GITHUB_OUTPUT
           echo "expectedTagName=v$(cat version/version.txt)" >> $GITHUB_OUTPUT
-
-      # Check publish.gradle version
-      - name: publish.gradle version check FAILED
-        if: ${{ steps.get_version.outputs.expectedTagName != env.TAG_NAME }}
-        run: |
-          echo Tag name: ${{ env.TAG_NAME }}
-          echo publish.gradle version: ${{ steps.get_version.outputs.version }}
-          exit 1
 
   prepare-release:
     runs-on: ubuntu-latest
@@ -86,19 +58,22 @@ jobs:
     steps:
       # Download API, docs, and version.txt
       - name: Download workflow artifacts
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@v6
         with:
           workflow: build.yml
           commit: ${{ github.sha }}
           path: '.'
 
+      # This step is to check what files are downloaded and how they are structured, as well as binary sizes for releases
+      - name: List files
+        run: |
+          ls -Rlh
+
       # Create new release draft
       - name: Create release
-        id: create_release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          VERSION=${{ needs.check-versions.outputs.version }}
-          TAG=v$VERSION
-          ls --recursive -l
-          gh release create $TAG CANBridge-${{ github.sha }}/* --repo $GITHUB_REPOSITORY --draft --title "Version $VERSION"
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          generate_release_notes: true
+          files: |
+            **/**


### PR DESCRIPTION
Updated workflows to better handle artifact uploads. This includes better cleanup of no longer dumping all the possible platforms into the main directory of the CI job, as well as for each platform type, specific artifacts for each platform is made to lower artifact sizes and to be specific to the correct platform.

Added macOS artifact creation.

Added ARM workflows and artifact creation.

Updated Release workflow for publishing releases and CI.

Updated dependent actions to latest supported.