### PR TITLE
Include both static and shared WPILib artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,8 +57,8 @@ jobs:
           halPlatformUrl=https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/hal/hal-cpp/"$halVersion"/hal-cpp-"$halVersion"-${{ matrix.platform-type }}.zip
           utilPlatformUrl=https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/wpiutil/wpiutil-cpp/"$halVersion"/wpiutil-cpp-"$halVersion"-${{ matrix.platform-type }}.zip
 
-          curl -o halPlatform.zip "$halPlatformUrl"
-          curl -o utilPlatform.zip "$utilPlatformUrl"
+          curl -L -o halPlatform.zip "$halPlatformUrl"
+          curl -L -o utilPlatform.zip "$utilPlatformUrl"
 
       - name: Unzip WPILib HAL artifacts and headers
         run: |
@@ -128,8 +128,8 @@ jobs:
           halPlatformUrl=https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/hal/hal-cpp/"$halVersion"/hal-cpp-"$halVersion"-${{ matrix.platform-type }}.zip
           utilPlatformUrl=https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/wpiutil/wpiutil-cpp/"$halVersion"/wpiutil-cpp-"$halVersion"-${{ matrix.platform-type }}.zip
 
-          curl -o halPlatform.zip "$halPlatformUrl"
-          curl -o utilPlatform.zip "$utilPlatformUrl"
+          curl -L -o halPlatform.zip "$halPlatformUrl"
+          curl -L -o utilPlatform.zip "$utilPlatformUrl"
 
       - name: Unzip WPILib HAL artifacts and headers
         run: |
@@ -184,8 +184,8 @@ jobs:
           halHeadersUrl=https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/hal/hal-cpp/"$halVersion"/hal-cpp-"$halVersion"-headers.zip
           utilHeadersUrl=https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/wpiutil/wpiutil-cpp/"$halVersion"/wpiutil-cpp-"$halVersion"-headers.zip
 
-          curl -o halHeaders.zip "$halHeadersUrl"
-          curl -o utilHeaders.zip "$utilHeadersUrl"
+          curl -L -o halHeaders.zip "$halHeadersUrl"
+          curl -L -o utilHeaders.zip "$utilHeadersUrl"
 
       - name: Unzip WPILib HAL artifacts and headers
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,25 +54,35 @@ jobs:
         run : |
           halVersion=$(cat wpiHalVersion.txt)
           
-          halPlatformUrl=https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/hal/hal-cpp/"$halVersion"/hal-cpp-"$halVersion"-${{ matrix.platform-type }}.zip
-          utilPlatformUrl=https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/wpiutil/wpiutil-cpp/"$halVersion"/wpiutil-cpp-"$halVersion"-${{ matrix.platform-type }}.zip
-
-          curl -L -o halPlatform.zip "$halPlatformUrl"
-          curl -L -o utilPlatform.zip "$utilPlatformUrl"
+          sharedHalPlatformUrl=https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/hal/hal-cpp/"$halVersion"/hal-cpp-"$halVersion"-${{ matrix.platform-type }}.zip
+          sharedUtilPlatformUrl=https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/wpiutil/wpiutil-cpp/"$halVersion"/wpiutil-cpp-"$halVersion"-${{ matrix.platform-type }}.zip
+          curl -L -o sharedHalPlatform.zip "$sharedHalPlatformUrl"
+          curl -L -o sharedUtilPlatform.zip "$sharedUtilPlatformUrl"
+          
+          staticHalPlatformUrl=https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/hal/hal-cpp/"$halVersion"/hal-cpp-"$halVersion"-${{ matrix.platform-type }}static.zip
+          staticUtilPlatformUrl=https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/wpiutil/wpiutil-cpp/"$halVersion"/wpiutil-cpp-"$halVersion"-${{ matrix.platform-type }}static.zip
+          curl -L -o staticHalPlatform.zip "$staticHalPlatformUrl"
+          curl -L -o staticUtilPlatform.zip "$staticUtilPlatformUrl"
 
       - name: Unzip WPILib HAL artifacts and headers
         run: |
-          unzip halPlatform.zip -d halPlatform
-          unzip utilPlatform.zip -d utilPlatform
-          mkdir -p CANBridge-artifacts
+          unzip sharedHalPlatform.zip -d sharedHalPlatform
+          unzip sharedUtilPlatform.zip -d sharedUtilPlatform
+          unzip staticHalPlatform.zip -d staticHalPlatform
+          unzip staticUtilPlatform.zip -d staticUtilPlatform
+          mkdir -p CANBridge-artifacts/static
+          mkdir -p CANBridge-artifacts/shared
 
       # Put Linux ARM release files together in one directory
       - name: Create Artifact
         run: |
-          cp build/libs/cANBridge/static/release/libCANBridge.a CANBridge-artifacts/libCANBridge.a
-          cp build/libs/cANBridge/shared/release/libCANBridge.so CANBridge-artifacts/libCANBridge.so
-          cp halPlatform/linux/${{ matrix.arch }}/shared/libwpiHal.so CANBridge-artifacts/libwpiHal.so
-          cp utilPlatform/linux/${{ matrix.arch }}/shared/libwpiutil.so CANBridge-artifacts/libwpiutil.so
+          cp build/libs/cANBridge/shared/release/libCANBridge.so CANBridge-artifacts/shared/libCANBridge.so
+          cp sharedHalPlatform/linux/${{ matrix.arch }}/shared/libwpiHal.so CANBridge-artifacts/shared/libwpiHal.so
+          cp sharedUtilPlatform/linux/${{ matrix.arch }}/shared/libwpiutil.so CANBridge-artifacts/shared/libwpiutil.so
+          
+          cp build/libs/cANBridge/static/release/libCANBridge.a CANBridge-artifacts/static/libCANBridge.a
+          cp staticHalPlatform/linux/${{ matrix.arch }}/static/libwpiHal.a CANBridge-artifacts/static/libwpiHal.a
+          cp staticUtilPlatform/linux/${{ matrix.arch }}/static/libwpiutil.a CANBridge-artifacts/static/libwpiutil.a
 
       # Upload build artifact
       - name: Upload build artifact
@@ -125,40 +135,56 @@ jobs:
         run : |
           halVersion=$(cat wpiHalVersion.txt)
 
-          halPlatformUrl=https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/hal/hal-cpp/"$halVersion"/hal-cpp-"$halVersion"-${{ matrix.platform-type }}.zip
-          utilPlatformUrl=https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/wpiutil/wpiutil-cpp/"$halVersion"/wpiutil-cpp-"$halVersion"-${{ matrix.platform-type }}.zip
-
-          curl -L -o halPlatform.zip "$halPlatformUrl"
-          curl -L -o utilPlatform.zip "$utilPlatformUrl"
+          sharedHalPlatformUrl=https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/hal/hal-cpp/"$halVersion"/hal-cpp-"$halVersion"-${{ matrix.platform-type }}.zip
+          sharedUtilPlatformUrl=https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/wpiutil/wpiutil-cpp/"$halVersion"/wpiutil-cpp-"$halVersion"-${{ matrix.platform-type }}.zip
+          curl -L -o sharedHalPlatform.zip "$sharedHalPlatformUrl"
+          curl -L -o sharedUtilPlatform.zip "$sharedUtilPlatformUrl"
+          
+          staticHalPlatformUrl=https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/hal/hal-cpp/"$halVersion"/hal-cpp-"$halVersion"-${{ matrix.platform-type }}static.zip
+          staticUtilPlatformUrl=https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/wpiutil/wpiutil-cpp/"$halVersion"/wpiutil-cpp-"$halVersion"-${{ matrix.platform-type }}static.zip
+          curl -L -o staticHalPlatform.zip "$staticHalPlatformUrl"
+          curl -L -o staticUtilPlatform.zip "$staticUtilPlatformUrl"
 
       - name: Unzip WPILib HAL artifacts and headers
         run: |
-          unzip halPlatform.zip -d halPlatform
-          unzip utilPlatform.zip -d utilPlatform
-          mkdir -p CANBridge-artifacts
+          unzip sharedHalPlatform.zip -d sharedHalPlatform
+          unzip sharedUtilPlatform.zip -d sharedUtilPlatform
+          unzip staticHalPlatform.zip -d staticHalPlatform
+          unzip staticUtilPlatform.zip -d staticUtilPlatform
+          mkdir -p CANBridge-artifacts/static
+          mkdir -p CANBridge-artifacts/shared
 
       # Put release files together in one directory based on platform
       - name: Create Artifact
         run: |
           mkdir -p CANBridge-artifacts
           if [[ "${{ matrix.platform-type }}" == "windowsx86-64" ]]; then
-            cp build/libs/cANBridge/static/windowsx86-64/release/CANBridge.lib CANBridge-artifacts/CANBridge-static.lib
-            cp build/libs/cANBridge/shared/windowsx86-64/release/CANBridge.dll CANBridge-artifacts/CANBridge.dll
-            cp build/libs/cANBridge/shared/windowsx86-64/release/CANBridge.lib CANBridge-artifacts/CANBridge.lib
-            cp halPlatform/windows/x86-64/shared/wpiHal.dll CANBridge-artifacts/wpiHal.dll
-            cp halPlatform/windows/x86-64/shared/wpiHal.lib CANBridge-artifacts/wpiHal.lib
-            cp utilPlatform/windows/x86-64/shared/wpiutil.dll CANBridge-artifacts/wpiutil.dll
-            cp utilPlatform/windows/x86-64/shared/wpiutil.lib CANBridge-artifacts/wpiutil.lib
+            cp build/libs/cANBridge/shared/windowsx86-64/release/CANBridge.dll CANBridge-artifacts/shared/
+            cp build/libs/cANBridge/shared/windowsx86-64/release/CANBridge.lib CANBridge-artifacts/shared/
+            cp sharedHalPlatform/windows/x86-64/shared/wpiHal.dll CANBridge-artifacts/shared/
+            cp sharedHalPlatform/windows/x86-64/shared/wpiHal.lib CANBridge-artifacts/shared/
+            cp sharedUtilPlatform/windows/x86-64/shared/wpiutil.dll CANBridge-artifacts/shared/
+            cp sharedUtilPlatform/windows/x86-64/shared/wpiutil.lib CANBridge-artifacts/shared/
+            
+            cp build/libs/cANBridge/static/windowsx86-64/release/CANBridge.lib CANBridge-artifacts/static/
+            cp staticHalPlatform/windows/x86-64/static/wpiHal.lib CANBridge-artifacts/static/
+            cp staticUtilPlatform/windows/x86-64/static/wpiutil.lib CANBridge-artifacts/static/
           elif [[ "${{ matrix.platform-type }}" == "linuxx86-64" ]]; then
-            cp build/libs/cANBridge/static/linuxx86-64/release/libCANBridge.a CANBridge-artifacts/libCANBridge.a
-            cp build/libs/cANBridge/shared/linuxx86-64/release/libCANBridge.so CANBridge-artifacts/libCANBridge.so
-            cp halPlatform/linux/x86-64/shared/libwpiHal.so CANBridge-artifacts/libwpiHal.so
-            cp utilPlatform/linux/x86-64/shared/libwpiutil.so CANBridge-artifacts/libwpiutil.so
+            cp build/libs/cANBridge/shared/linuxx86-64/release/libCANBridge.so CANBridge-artifacts/shared/
+            cp sharedHalPlatform/linux/x86-64/shared/libwpiHal.so CANBridge-artifacts/shared/
+            cp sharedUtilPlatform/linux/x86-64/shared/libwpiutil.so CANBridge-artifacts/shared/
+            
+            cp build/libs/cANBridge/static/linuxx86-64/release/libCANBridge.a CANBridge-artifacts/static/
+            cp staticHalPlatform/linux/x86-64/static/libwpiHal.a CANBridge-artifacts/static/
+            cp staticUtilPlatform/linux/x86-64/static/libwpiutil.a CANBridge-artifacts/static/
           elif [[ "${{ matrix.platform-type }}" == "osxuniversal" ]]; then
-            cp build/libs/cANBridge/static/osxuniversal/release/libCANBridge.a CANBridge-artifacts/libCANBridge.a
-            cp build/libs/cANBridge/shared/osxuniversal/release/libCANBridge.dylib CANBridge-artifacts/libCANBridge.dylib
-            cp halPlatform/osx/universal/shared/libwpiHal.dylib CANBridge-artifacts/libwpiHal.dylib
-            cp utilPlatform/osx/universal/shared/libwpiutil.dylib CANBridge-artifacts/libwpiutil.dylib
+            cp build/libs/cANBridge/shared/osxuniversal/release/libCANBridge.dylib CANBridge-artifacts/shared/
+            cp sharedHalPlatform/osx/universal/shared/libwpiHal.dylib CANBridge-artifacts/shared/
+            cp sharedUtilPlatform/osx/universal/shared/libwpiutil.dylib CANBridge-artifacts/shared
+            
+            cp build/libs/cANBridge/static/osxuniversal/release/libCANBridge.a CANBridge-artifacts/static/
+            cp staticHalPlatform/osx/universal/static/libwpiHal.a CANBridge-artifacts/static/
+            cp staticUtilPlatform/osx/universal/static/libwpiutil.a CANBridge-artifacts/static/
           fi
 
       # Upload build artifact


### PR DESCRIPTION
The plan is to link `node-can-bridge`'s dependencies statically in the future (see https://github.com/REVrobotics/node-can-bridge/issues/13). I did at least some spot-checking of the results when run in GitHub Actions here: https://github.com/REVrobotics/CANBridge/pull/44

This PR also ports over https://github.com/REVrobotics/CANBridge/commit/44bdc5b4272a996795446b90d28b69e0e2caf9d7, which fixes CI after a recent change to WPILib's Artifactory instance.